### PR TITLE
Make GitHub detect *.txt as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/forth/*.txt linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `.txt.` files in the `forth` directory as Forth.

Thanks!
